### PR TITLE
Added definitions

### DIFF
--- a/dist/acho.d.ts
+++ b/dist/acho.d.ts
@@ -1,0 +1,10 @@
+declare class Acho {
+  constructor(options?: Object);
+  debug(...args: string[]): void;
+  error(...args: string[]): void;
+  fatal(...args: string[]): void;
+  info(...args: string[]): void;
+  warn(...args: string[]): void;
+}
+
+export = Acho;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://github.com/achohq/acho",
   "version": "3.1.0",
   "main": "./index.js",
+  "types": "./dist/acho.d.ts",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",
     "name": "Kiko Beats",


### PR DESCRIPTION
I wanted to use Acho in a TypeScript project but it was missing type definitions, so I started and created an initial definition file, according to: http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Acho can then be used the following way:

``` typescript
import Acho = require("acho");

let logger: Acho= new Acho();
logger.info('Hello from Acho!');
```
